### PR TITLE
Initial b3e implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+
+jobs:
+  test-ruby:
+    runs-on: ubuntu-latest
+
+    name: ${{ matrix.ruby }}
+
+    strategy:
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+
+      - name: Install Dependencies
+        shell: bash -l -e -o pipefail {0}
+        run: |
+          rm -f Gemfile.lock
+          bundle install --jobs=3 && bundle update --jobs=3
+
+      - name: Run Linter
+        shell: bash -l -e -o pipefail {0}
+        run: |
+          CI=true bundle exec standardrb
+
+      - name: Run Tests
+        shell: bash -l -e -o pipefail {0}
+        run: |
+          CI=true bundle exec rake test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,83 @@
 # b3e
 
-Fast Base62 for Ruby.
+Fast Base62 encoding/decoding for Ruby strings.
+
+```ruby
+require "b3e"
+
+B3e.encode("hello")
+=> "vxGblhG"
+
+B3e.decode("vxGblhG")
+=> "hello"
+```
+
+## Rationale
+
+Base62 creates url-safe, user-friendly strings from arbitrary bytes. It's similar to Base64 encoding, but restricted to
+an alphanumeric alphabet. This means that Base62 strings contain no special characters and can be easily selected by a
+user, making them ideal for things that a user will interact with—like api keys.
+
+This library pulls inspiration from the [glowfall/base62](https://github.com/glowfall/base62) and
+[jxskiss/base62](https://github.com/jxskiss/base62) projects to make encoding and decoding fast enough for nearly any
+use case. Here's a benchmark for encoding 512 random bytes:
+
+```
+$ bundle exec ruby benchmarks/encode.rb
+
+Warming up --------------------------------------
+                 b3e    34.943k i/100ms
+              base64    36.338k i/100ms
+Calculating -------------------------------------
+                 b3e    368.076k (± 3.7%) i/s -      1.852M in   5.038917s
+              base64    355.178k (± 3.3%) i/s -      1.781M in   5.019292s
+
+Comparison:
+                 b3e:   368076.4 i/s
+              base64:   355178.1 i/s - same-ish: difference falls within error
+```
+
+And here's a benchmark for decoding the encoded strings from above:
+
+```
+$ bundle exec ruby benchmarks/decode.rb
+
+Warming up --------------------------------------
+                 b3e    61.821k i/100ms
+              base64    35.402k i/100ms
+Calculating -------------------------------------
+                 b3e    612.307k (± 4.5%) i/s -      3.091M in   5.058411s
+              base64    312.973k (±11.0%) i/s -      1.558M in   5.040309s
+
+Comparison:
+                 b3e:   612306.9 i/s
+              base64:   312973.3 i/s - 1.96x  (± 0.00) slower
+```
+
+Compared to Ruby's built-in Base64 encoder, `b3e` encodes at a similar rate but is actually *faster* at decoding.
+
+## Tradeoffs
+
+`b3e` is plenty fast, but it comes with a tradeoff. The encodings that `b3e` generates are less portable because it
+uses a different algorithm than most other Base62 encoders. Here's a comparison between `b3e` and `b3bm` (a Base62
+encoder that takes more of a standard tack):
+
+```ruby
+B3e.encode("hello")
+=> "vxGblhG"
+
+B3bm.encode("hello")
+=> "7tQLFHz"
+```
+
+*What this means is that encodings generated with `b3e` might not decode correctly by Base62 libraries in other
+ecosystems.* Base62 lacks a formally defined standard so there is already quite a bit of variability between
+libraries, but keep this in mind if your encodings need to be consumed by other tools.
+
+## Alternatives
+
+Here's a couple other approaches in the Ruby ecosystem:
+
+* [`b3bm`](https://github.com/metabahn/b3bm): Counterpart to `b3e`, but generates more portable encodings a lot more slowly.
+* [`base62-rb`](https://github.com/steventen/base62-rb): Base62 encoder/decoder for integers, implemented in Ruby.
+* [`yab62`](https://github.com/siong1987/yab62): Base62 encoder/decoder for integers, implemented in C.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "rake/extensiontask"
+
+Rake::ExtensionTask.new "b3e_ext" do |ext|
+  ext.ext_dir = "ext/b3e"
+end
+
+task test: :compile do
+  unless system "bundle exec rspec"
+    exit $?.exitstatus
+  end
+end
+
+task :clean do
+  [
+    "./lib/b3e_ext.bundle"
+  ].each do |file|
+    next unless File.exist?(file)
+
+    FileUtils.rm(file)
+  end
+end
+
+task build: %i[test clean] do
+  system "gem build b3e.gemspec"
+end

--- a/benchmarks/decode.rb
+++ b/benchmarks/decode.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "base64"
+require "benchmark/ips"
+require "securerandom"
+
+require "b3e"
+
+string = SecureRandom.random_bytes(512)
+
+encoded62 = B3e.encode(string)
+encoded64 = Base64.urlsafe_encode64(string, padding: false)
+
+Benchmark.ips do |ips|
+  ips.config(time: 5, warmup: 1)
+
+  ips.report("b3e") do
+    B3e.decode(encoded62)
+  end
+
+  ips.report("base64") do
+    Base64.urlsafe_decode64(encoded64)
+  end
+
+  ips.compare!
+end

--- a/benchmarks/encode.rb
+++ b/benchmarks/encode.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "base64"
+require "benchmark/ips"
+require "securerandom"
+
+require "b3e"
+
+string = SecureRandom.random_bytes(512)
+
+Benchmark.ips do |ips|
+  ips.config(time: 5, warmup: 1)
+
+  ips.report("b3e") do
+    B3e.encode(string)
+  end
+
+  ips.report("base64") do
+    Base64.urlsafe_encode64(string, padding: false)
+  end
+
+  ips.compare!
+end

--- a/ext/b3e/b3e_ext.c
+++ b/ext/b3e/b3e_ext.c
@@ -1,0 +1,154 @@
+/*
+  This software is licensed under the MPL-2.0 License.
+
+  Copyright Bryan Powell, 2021.
+*/
+
+#include <math.h>
+#include <ruby/ruby.h>
+
+static const char ALPHABET[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+static const int INDEX[] = {
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+  52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1,
+  -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+  15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1,
+  -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+  41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51
+};
+
+int COMPACT_MASK = 0x1E;
+int MASK_5BITS = 0x1F;
+
+VALUE cInvalid;
+
+static VALUE rb_b3e_encode(VALUE self, VALUE rString) {
+  char* string = StringValuePtr(rString);
+  char encoded[RSTRING_LEN(rString) * 8 / 5 + 1];
+
+  int64_t cursor1 = RSTRING_LEN(rString) * 8;
+  int64_t cursor2;
+  int64_t i;
+
+  char j;
+  char blen1;
+  char blen2;
+  char shift;
+  unsigned char byte;
+  int written = 0;
+
+  while (1) {
+    j = 0;
+    i = 0;
+
+    cursor2 = cursor1 - 6;
+    if (cursor2 <= 0) {
+      cursor2 = 0;
+      blen1 = cursor1;
+    } else {
+      i = cursor2 / 8;
+      j = cursor2 % 8;
+      blen1 = (i + 1) * 8 - cursor2;
+      if (blen1 > 6) {
+        blen1 = 6;
+      }
+    }
+
+    shift = 8 - j - blen1;
+    byte = (unsigned char)string[i] >> shift & ((1 << blen1) - 1);
+    if (blen1 < 6 && cursor2 > 0) {
+      blen2 = 6 - blen1;
+      byte = (byte << blen2) | ((unsigned char)string[i + 1] >> (8 - blen2));
+    }
+
+    if ((byte & COMPACT_MASK) == COMPACT_MASK) {
+      if (cursor2 > 0 || byte > MASK_5BITS) {
+        cursor2++;
+      }
+
+      byte &= MASK_5BITS;
+    }
+
+    cursor1 = cursor2;
+    encoded[written] = ALPHABET[byte];
+    written++;
+
+    if (cursor2 <= 0) {
+      break;
+    }
+  }
+
+  return rb_str_new(encoded, written);
+}
+
+static VALUE rb_b3e_decode(VALUE self, VALUE rString) {
+  char* string = StringValuePtr(rString);
+
+  u_int64_t length = RSTRING_LEN(rString);
+  u_int64_t size = length * 6 / 8;
+  u_int64_t index;
+
+  char decoded[size];
+  u_int64_t cursor = size;
+  unsigned char character;
+  int x;
+  int byte = 0;
+  int position = 0;
+  int cb;
+
+  for (index = 0; index < length; index++) {
+    character = string[index];
+    x = INDEX[character];
+
+    if (x == -1) {
+      rb_raise(cInvalid, "encountered a character that is not in the base62 alphabet");
+    }
+
+    if (index == length - 1) {
+      byte |= x << position;
+      cb = position % 8;
+      position += (cb == 0 ? 0 : 8 - cb);
+    } else if ((x & COMPACT_MASK) == COMPACT_MASK) {
+      byte |= x << position;
+      position += 5;
+    } else {
+      byte |= x << position;
+      position += 6;
+    }
+
+    if (position >= 8) {
+      cursor--;
+      decoded[cursor] = byte;
+      position %= 8;
+      byte >>= 8;
+    }
+  }
+
+  if (position > 0) {
+    cursor--;
+    decoded[cursor] = byte;
+  }
+
+  if (cursor > 0) {
+    char resized[size];
+
+    for (index = 0; index < size; index++) {
+      resized[index] = decoded[cursor + index];
+    }
+
+    return rb_str_new(resized, size - cursor);
+  } else {
+    return rb_str_new(decoded, size);
+  }
+}
+
+void Init_b3e_ext(void) {
+  VALUE mB3e = rb_const_get(rb_cObject, rb_intern("B3e"));
+  cInvalid = rb_const_get(mB3e, rb_intern("Invalid"));
+
+  rb_define_singleton_method(mB3e, "c_encode", rb_b3e_encode, 1);
+  rb_define_singleton_method(mB3e, "c_decode", rb_b3e_decode, 1);
+}

--- a/ext/b3e/extconf.rb
+++ b/ext/b3e/extconf.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+dir_config("b3e_ext")
+create_makefile("b3e_ext")

--- a/lib/b3e.rb
+++ b/lib/b3e.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module B3e
+  # [public] Raised when the value cannot be encoded or decoded.
+  #
+  class Invalid < StandardError
+  end
+
+  # [public] Encode a string as Base62.
+  #
+  def self.encode(value)
+    if value.size > 0
+      c_encode(value)
+    else
+      ""
+    end
+  end
+
+  # [public] Decode a Base62 string back to its original value.
+  #
+  def self.decode(value)
+    if value.size > 0
+      c_decode(value)
+    else
+      ""
+    end
+  end
+
+  require_relative "b3e/version"
+end
+
+require_relative "b3e_ext"

--- a/lib/b3e/version.rb
+++ b/lib/b3e/version.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module B3e
+  VERSION = "0.0.0"
+
+  def self.version
+    VERSION
+  end
+end

--- a/spec/failures/invalid_decode_spec.rb
+++ b/spec/failures/invalid_decode_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "b3e"
+
+RSpec.describe "decoding an invalid string" do
+  it "raises" do
+    expect {
+      B3e.decode("abc$")
+    }.to raise_error(B3e::Invalid, "encountered a character that is not in the base62 alphabet")
+  end
+end

--- a/spec/features/edges_spec.rb
+++ b/spec/features/edges_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "b3e"
+
+RSpec.describe "edge cases" do
+  let(:result) {
+    B3e.decode(B3e.encode(string))
+  }
+
+  context "sting is empty" do
+    let(:string) {
+      ""
+    }
+
+    it "encodes and decodes" do
+      expect(result).to eq(string)
+    end
+  end
+
+  context "string has leading zero" do
+    let(:string) {
+      "\x00s$\x02\xB3I".b
+    }
+
+    it "encodes and decodes" do
+      expect(result).to eq(string)
+    end
+  end
+
+  context "string has many leading zeros" do
+    let(:string) {
+      "\x00\x00\x00s$\x02\xB3I".b
+    }
+
+    it "encodes and decodes" do
+      expect(result).to eq(string)
+    end
+  end
+
+  context "string has leading zero and zeroes within" do
+    let(:string) {
+      "\x00s$\x02\x00\xB3I".b
+    }
+
+    it "encodes and decodes" do
+      expect(result).to eq(string)
+    end
+  end
+end

--- a/spec/features/random_spec.rb
+++ b/spec/features/random_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require "b3e"
+
+RSpec.describe "using b3e with random alphanumerics" do
+  1_000.times do
+    string = SecureRandom.alphanumeric((rand * 100).to_i)
+
+    it "encodes and decodes: #{string}" do
+      encoded = B3e.encode(string)
+      expect(encoded).to match(/^[a-zA-Z0-9]*$/)
+      expect(B3e.decode(encoded)).to eq(string)
+    end
+  end
+end
+
+RSpec.describe "using b3e with random bytes" do
+  1_000.times do
+    string = SecureRandom.random_bytes((rand * 100).to_i)
+
+    it "encodes and decodes: #{string}" do
+      expect(B3e.decode(B3e.encode(string))).to eq(string)
+    end
+  end
+end

--- a/spec/features/simple_spec.rb
+++ b/spec/features/simple_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "b3e"
+
+RSpec.describe "simple encode/decode" do
+  it "encodes" do
+    expect(B3e.encode("abc")).to eq("jJWY")
+  end
+
+  it "decodes" do
+    expect(B3e.decode("jJWY")).to eq("abc")
+  end
+
+  it "encodes single character strings" do
+    expect(B3e.encode("0")).to eq("wA")
+  end
+
+  it "encodes a longer string" do
+    string = "mGJnOID9uf7lOyrd4O7Z0QStsr0ySBRi55b6wXtaY4MFG8KgL4PFWtC7SJSEmpfHpOPd80hMwnOZxj363bkhsU3CMdB1D23T259HMUeJ2V9qiNq8rZpvxEQm1di1jYnq"
+    result = "x5WWqFTakFTbRVEesDOtkDn4cKt4yxKZUqsqaCpcqRGqmRGiiRIyaaoZqaO0WTsZsZG1wTrnc7umQDGcIDqngDJzgrtimSppuZI6uyIoohpzWCnjMqJayKM6w6ObErmaSTKhmKPYkbO6mKKY06mnohM5y7J2uxs6yhokekbKdUb"
+
+    expect(B3e.encode(string)).to eq(result)
+  end
+
+  it "decodes a longer string" do
+    string = "mGJnOID9uf7lOyrd4O7Z0QStsr0ySBRi55b6wXtaY4MFG8KgL4PFWtC7SJSEmpfHpOPd80hMwnOZxj363bkhsU3CMdB1D23T259HMUeJ2V9qiNq8rZpvxEQm1di1jYnq"
+    result = "x5WWqFTakFTbRVEesDOtkDn4cKt4yxKZUqsqaCpcqRGqmRGiiRIyaaoZqaO0WTsZsZG1wTrnc7umQDGcIDqngDJzgrtimSppuZI6uyIoohpzWCnjMqJayKM6w6ObErmaSTKhmKPYkbO6mKKY06mnohM5y7J2uxs6yhokekbKdUb"
+
+    expect(B3e.decode(result)).to eq(string)
+  end
+
+  it "encodes and decodes a longer string" do
+    string = "NQvsbx5zmwSyjgIOab1DJwZbKWU4DfRNyWzipV5XuSyNkTrK4tYAo5RKc5XLFeyduCds8lLMzU8I2NKIEzaO0PcxwapI"
+
+    expect(B3e.decode(B3e.encode(string))).to eq(string)
+  end
+end


### PR DESCRIPTION
Counterpart to [`b3bm`](https://github.com/metabahn/b3bm), offering a faster approach to Base62 encoding/decoding strings in Ruby.